### PR TITLE
Expand ephys folder structure

### DIFF
--- a/docs/ephys/folder_structure.rst
+++ b/docs/ephys/folder_structure.rst
@@ -23,14 +23,14 @@ As a general rule, it is recommended to have a single data folder, with recordin
                 |- 2021-01-07_09-00-13
 
 
-
-
+THis page provides an overview of what a typical Session folder looks like for each recording system. The relevant files are listed. Other files may also be present, but aren't incorporated into the pipeline
 
 
 .. _Ephys folders npx:
 
 Neuropixels Recordings
 ---------------------------
+
 
 Neuropixel Folder Structure
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -56,18 +56,83 @@ The Neuropixel folder structure is based on Richard's models. The below example 
         |- sessions.txt
         |- sync_all.mat
 
-The relevant files are listed. Other files may also be present, but aren't incorporated into the pipeline
+A Neuropixels session is identified by the presence of one (or more) ``.ap.meta`` files underneatht eh session directory. They may be nested arbitrarily deep. There should be exactly the same number of ``.ap.meta`` files as there are probes inserted into the subject. 
 
-Tracking data is stored in the ``motive`` folder, and may either be in the `matmot` format, streamed via Matlab during acquisition, or in the `optitrack.csv` format output by Optitrack's software. 
+Tracking data is expected to be provided via the Optitrack motion capture system. Either data output format (see :ref:`Ephys folders optitrack`) is supported. Depending on the format, either:
+
+  * Matmot
+    
+    ``motive`` folder containing ``matmot.meta``, ``matmot.mtv``, ``sync.mat``. The directory and files are searched for by explicit naming
+  
+  * OptiCSV
+  
+    ``Optitrack`` folder containing a ``.csv`` file
 
 Ephys data is stored in ``probe_x`` folders, one per probe (2 in this case). Each ``probe_x`` folder contains the raw data in the form of ``.bin`` and ``.meta`` files. The exact name of these files is less important than the suffixes (``.ap.meta``, ``.ap.bin``, ``.lf.meta``, ``.lf.bin``)
-- First generation neuropixel probes have separate ``ap`` and `lf` files for high and low frequency data. 
+
+- First generation neuropixel probes have separate ``ap`` and ``lf`` files for high and low frequency data. 
 - Neuropixel 2.0 probes do not have ``lf`` data files, as all data is stored in the ``ap`` file. 
-- If clustered with Kilosort, it is expected that the Kilosort output for each probe will be stored inside that probe's directory.
+- If clustered with Kilosort, it is expected that the Kilosort output for each probe is typically stored in that probe's directory, but for the case of multiple clusterings, see :ref:`Ephys folders npx multiple-clusterings`
 
 Sync data is stored in the ``sync_all.mat`` and ``sync.mat`` files 
 
 Information on tasks is stored in ``sessions.txt``
+
+The Session may be ingested by providing the path ``../2020-06-17_12-35-40`` to the web gui.
+
+
+.. _Ephys folders npx multiple-clusterings:
+
+Multiple clusterings with multiple Neuropixel probes
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The standard way of storing multiple clustering outputs with Neuropixel probes is to store one folder per clustering, per probe, i.e. 
+
+.. code-block:: bash
+
+    |- 2020-06-17_12-35-40
+        |- probe_1
+            |- ks2.1_01
+                |- <Kilosort output here>
+            |- ks2.1_02
+                |- <Kilosort output here>
+            |- ks2.1_03
+                |- <Kilosort output here>
+        |- probe_2
+            |- ks2.1_01
+                |- <Kilosort output here>
+            |- ks2.1_02
+                |- <Kilosort output here>
+            |- ks2.1_03
+                |- <Kilosort output here>
+    
+That is to say: clusterings are first separated by probe, and then by clustering ID. However this standard approach causes problems with ingestion via the web GUI (see :ref:`Ephys web-gui`). The ingestion logic requires a single "parent folder" which contains exactly one clustering output per probe inserted into that subject, while the above approach will yield many clustering outputs per probe inserted. 
+
+The current work around is to modify this folder structure slightly instead: to separate *first* by curation ID and *then* by probe:
+
+.. code-block:: bash
+
+    |- 2020-06-17_12-35-40
+        |- probe_1
+        |- probe_2
+        |- curations
+            |- 01
+                |- probe_1
+                    |- ks2.1_01
+                        |- <Kilosort output here>
+                |- probe_2
+                    |- ks2.1_01
+                        |- <Kilosort output here>
+            |- 02
+                |- probe_1
+                    |- ks2.1_02
+                        |- <Kilosort output here>
+                |- probe_2
+                    |- ks2.1_02
+                        |- <Kilosort output here>
+
+In this case, you would provide the path ``../2020-06-17_12-35-40/curations/01`` as the curation output directory. 
+
 
 Supported Probes
 ^^^^^^^^^^^^^^^^^^^^^
@@ -79,18 +144,34 @@ The ephys pipeline supports the following Neuropixel probe models:
 * Neuropixel 2.0 single shank, model 21. Labelled as "neuropixels 2.0 - SS". 
 * Neuropixel 2.0 multiple shank, model 24. Labelled as "neuropixels 2.0 - MS". 
 
-The SpikeGLX wireless head stage for Neuropixel probes is currently NOT supported.
+The SpikeGLX wireless head stage for Neuropixel probes is currently NOT supported, unless individual users manually recreate the data structure explained above. 
 
 
 
 
 .. _Ephys folders wireless:
 
-Neuologger Recordings
+Neurologger Recordings
 ------------------------------
 
-TODO
+Neurologger (or Deuteron) recording folders should look something like this:
 
+.. code-block:: bash
+
+    |- 2020-06-17_12-35-40
+        |- Optitrack
+            optitrack.csv
+        |- Processed
+            <kilosort output>
+        |- Raw
+            EVENTLOG.CSV
+            EVENTLOG.NLE
+            NEUR0000.DT2
+            NEUR0001.DT"
+            ....
+        neurologger_header.mat
+
+A Neurologger Session is primarily identified by the presence of a ``neurologger_header.mat`` file. 
 
 
 
@@ -99,20 +180,41 @@ TODO
 Axona Recordings
 ----------------------------
 
-TODO
+Standard practice is to place all Recordings for a single Session in a single folder
+
+.. code-block:: bash
+
+    |- 2020-06-17_12-35-40
+        2020-06-17_openfield.1
+        2020-06-17_openfield.2
+        2020-06-17_openfield.3
+        2020-06-17_openfield.4
+        2020-06-17_openfield.eeg
+        2020-06-17_openfield.eeg2
+        2020-06-17_openfield.eeg3
+        2020-06-17_openfield.eeg4
+        2020-06-17_openfield.inp
+        2020-06-17_openfield.pos
+        2020-06-17_openfield.set
+        2020-06-17_laser_1.1
+        2020-06-17_laser_1.2
+        <...>
+
+Ingestion does not currently support recordings nested into individual folders. 
+
+The Session may be ingested by providing the path ``../2020-06-17_12-35-40`` to the web gui.
+
+An Axona Recording is identified by a single ``.set`` file. All Axona recordings in the same folder are considered to be members of the same Session. 
 
 
-
-
-.._ Ephys folders neuralynx:
+.. _Ephys folders neuralynx:
 
 Neuralynx Recordings
 ------------------------------
 
-TODO
+Multiple recordings per Session are not supported for Neuralynx data.
 
-
-
+A Neuralynx recording is identified by the presence of exactly 1 ``.ntt`` file. 
 
 
 .. _Ephys folders sessions:
@@ -120,7 +222,7 @@ TODO
 Sessions.txt
 ------------------------------
 
-Thie is s standardised format for storing information about tasks, from Richard's neuropixel software. The same format can also be used for any other probe model.
+Thie is a standardised format for storing information about tasks, from Richard's neuropixel software. The same format can also be used for any other probe model.
 
 Sessions.txt should be a basic text file, with columns delimited by commas
 
@@ -132,3 +234,33 @@ Sessions.txt should be a basic text file, with columns delimited by commas
 
     #1,    open_field_1    start=30    <RUNNING>
 
+
+.. _Ephys folders optitrack:
+
+OptiTrack tracking data
+-----------------------------
+
+Optitrack is a commercial motion capture system. The Moser group makes use of two parallel methods of recording motion capture data.
+
+CSV
+^^^^^^^^^^^
+
+The simplest option is to run Optitrack's own software to record and process the data, and then export the data as a CSV file. 
+
+Timestamp synchronisation relies on TTL logic, with the OptiTrack system sending a TTL pulse to the data acquisition system (either Neurologger or Neuropixels) each time a frame is recorded. The data acquisition system records this pulse train as a set of timestamps, which are later assigned to each frame of tracking, in order. 
+
+This method is typically used with Neurologger recordings. 
+
+If at any time the Optitrack software crashes, then all the recording must stop, as an unknown number of frames will be missed, and no further tracking may be synchronised.
+
+
+Matmot
+^^^^^^^^^^
+
+In order to solve the problem where a software crash could invalidate a large amount of recording data, an alternative synchronisation method is used, mostly with Neuropixel recordings. 
+
+A group of infra-red LEDs are positioned around the arena where they can be observed by one or more Optitrack cameras, controlled by an Arduino. The LEDs are flashed with a pseudorandom pattern, which is also transmitted to the data acquisition system as a stream of TTL pulses. 
+
+The Optitrack software is configured to recognise the IR LEDs as an additional rigid body; and additionally is configured to stream data into a ``.mat`` data file as each frame is recorded. If the software crashes, then it can be restarted, and continue streaming, some time period later.
+
+Synchronisation is then performed by correlating the existence of the sync rigid body in the .mat files to the pseudorandom pulse code recorded by the data acquisition system. This method allows a long recording to continue even after the optitrack software crashes and is restarted, although in the tracking data some time periods will be absent. 

--- a/docs/ephys/ingestion_webgui.rst
+++ b/docs/ephys/ingestion_webgui.rst
@@ -1,5 +1,7 @@
+.. _Ephys web-gui:
+
 =======================================
-Ephys: Ingesting data with the web gui
+Ephys: Web GUI
 =======================================
 
 Data can be ingested into the ephys pipeline in two different ways. All users are encouraged to use the web GUI. Advanced users may insert directly into the pipeline via Python or Matlab scripts. 
@@ -123,7 +125,7 @@ Once a subject implant has been recorded, the Session Ingestion becomes the main
     
     - Specify the **Curation Time**, which is used to uniquely identify the clustering results, in the case of multiple clusterings being saved
     
-    - Specify the **Curation Output Directory**, the location where clustering output is saved. The background worker will perform a recursive search from this directory to find any supported clustering outputs. In the case of a multi-probe clustering, you should select an outer folder which will include a clustering output for *each* probe.
+    - Specify the **Curation Output Directory**, the location where clustering output is saved. The background worker will perform a recursive search from this directory to find any supported clustering outputs. In the case of a multi-probe clustering, you should select an outer folder which will include a clustering output for *each* probe (see also :ref:`Ephys folders npx multiple-clusterings`
   
   .. figure:: /_static/ephys/webgui/add_clustering_1.PNG
      :alt: Adding single-session clustering


### PR DESCRIPTION
* Add details for Axona
* Add details for Neurologger
* Add details for Optitrack
* Explain how to deal with multiple clusterings for multiple probes (see https://github.com/kavli-ntnu/dj-elphys/issues/71)

Also updated to detail where specific files or formats are searched for, e.t. matmot.mtv is searched for by directory and name specifically. Optitrack csv is searched for by file format, and the presence of a version number inside its header. 